### PR TITLE
削除画面に削除対象のレコード情報を表示

### DIFF
--- a/web_application_2/src/components/Form.vue
+++ b/web_application_2/src/components/Form.vue
@@ -22,6 +22,7 @@
             <v-text-field
               label="タイトル"
               v-model="book.title"
+              v-bind:disabled="disabled"
             ></v-text-field>
           </v-col>
         </v-row>
@@ -33,6 +34,7 @@
             <v-text-field
               label="ジャンル"
               v-model="book.genre"
+              v-bind:disabled="disabled"
             ></v-text-field>
           </v-col>
         </v-row>
@@ -57,6 +59,7 @@
                   readonly
                   v-bind="attrs"
                   v-on="on"
+                  v-bind:disabled="disabled"
                 ></v-text-field>
               </template>
               <v-date-picker
@@ -74,6 +77,7 @@
             <v-text-field
               label="購入者"
               v-model="book.buyer"
+              v-bind:disabled="disabled"
             ></v-text-field>
           </v-col>
         </v-row>
@@ -86,6 +90,7 @@
               name="review"
               label="レビュー"
               v-model="book.review"
+              v-bind:disabled="disabled"
             ></v-textarea>
           </v-col>
         </v-row>
@@ -149,10 +154,17 @@ export default {
   },
   data () {
     return {
-      menu: false
+      menu: false,
+      disabled: false
     }
   },
-  created () {},
+  created () {
+    if (this.formType === 'delete') {
+      this.disabled = true
+    } else {
+      this.disabled = false
+    }
+  },
   computed: {},
   methods: {
     addNewBook () {

--- a/web_application_2/src/view/BookApp.vue
+++ b/web_application_2/src/view/BookApp.vue
@@ -18,7 +18,7 @@
       v-model="deleteBookDialog"
       width="550"
     >
-      <Form @deleteBook="deleteBook" formType="delete"/>
+      <Form @deleteBook="deleteBook" formType="delete" :book="this.book"/>
     </v-dialog>
     <v-overlay
       :value="overlay"
@@ -88,7 +88,16 @@ export default {
 
       this.editBookDialog = true
     },
-    openDeleteDialog () {
+    openDeleteDialog (item) {
+      this.$set(this.book, 'id', item.id)
+      this.$set(this.book, 'createdAt', item.createdAt)
+      this.$set(this.book, 'updatedAt', item.updatedAt)
+      this.$set(this.book, 'title', item.title)
+      this.$set(this.book, 'genre', item.genre)
+      this.$set(this.book, 'boughtAt', item.boughtAt)
+      this.$set(this.book, 'buyer', item.buyer)
+      this.$set(this.book, 'review', item.review)
+
       this.deleteBookDialog = true
     },
     maxIdSearch (books) {


### PR DESCRIPTION
@hyamakawa 
WEBアプリ開発２の「6-2.削除ボタンを押した際に選択したレコードの内容が、削除画面の各項目に表示されるようにする（入力はできない状態）」を対応しました。
レビューをお願いします。
![image](https://github.com/h-yokoyama-eiwa/tutorial/assets/67628682/715285b6-ce69-40f1-aa77-c70a1ad4f11c)
![image](https://github.com/h-yokoyama-eiwa/tutorial/assets/67628682/01078e74-b0ad-4b23-a19e-6a3da8f419cc)
